### PR TITLE
develop -> v1

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -14,7 +14,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0

--- a/.github/workflows/adocs-build-v1-legacy.yml
+++ b/.github/workflows/adocs-build-v1-legacy.yml
@@ -14,7 +14,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: v1
           submodules: true

--- a/.github/workflows/adocs-build-v1-production.yml
+++ b/.github/workflows/adocs-build-v1-production.yml
@@ -14,7 +14,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: v1
           submodules: true

--- a/.github/workflows/adocs-build-v1-staging.yml
+++ b/.github/workflows/adocs-build-v1-staging.yml
@@ -14,7 +14,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: v1
           submodules: true

--- a/docs/Om_denne_spesifikasjonen.adoc
+++ b/docs/Om_denne_spesifikasjonen.adoc
@@ -67,7 +67,7 @@ Spesifikasjonen bruker kravnivåene «obligatorisk», «anbefalt» og «valgfri�
 |rdfs |http://www.w3.org/2000/01/rdf-schema# |https://www.w3.org/TR/rdf-schema/[RDF Schema 1.1]
 |schema |http://schema.org/ | https://schema.org/[Schema.org]
 |skos |http://www.w3.org/2004/02/skos/core# |https://www.w3.org/TR/skos-reference/[SKOS Simple Knowledge Organization System]
-|uneskos |http://purl.org/umu/uneskos# |https://skos.um.es/TR/uneskos/[UNESKOS Vocabulary]
+|uneskos |http://purl.org/umu/uneskos# | UNESKOS Vocabulary
 |xkos |http://rdf-vocabulary.ddialliance.org/xkos# |https://rdf-vocabulary.ddialliance.org/xkos.html[An SKOS extension for representing statistical classifications]
 |xsd |http://www.w3.org/2001/XMLSchema# |https://www.w3.org/TR/xmlschema-2/[XML Schema Part 2: Datatypes Second Edition]
 |===

--- a/docs/main.adoc
+++ b/docs/main.adoc
@@ -14,9 +14,9 @@ ifdef::backend-pdf[:toc: macro]
 image::images/Digdir.png[width=30%, pdfwidth=30vw, link=https://digdir.no/]
 
 *Status*: Gjeldende +
-*Versjon*: 1.0.2 +
+*Versjon*: 1.0.3 +
 *Publisert*: 2022-06-28 (v.1.0) +
-*Oppdatert*: 2023-11-03 (v.1.0.x, se <<Endringslogg, endringslogg>>) +
+*Oppdatert*: 2025-08-22 (v.1.0.x, se <<Endringslogg, endringslogg>>) +
 *Gjeldende versjon*: https://data.norge.no/specification/xkos-ap-no/ +
 *Redaktørens utkast*: https://informasjonsforvaltning.github.io/xkos-ap-no/ +
 *Valideringsverktøy*: https://data.norge.no/validator (ved å oppgi URLen til https://raw.githubusercontent.com/Informasjonsforvaltning/xkos-ap-no/develop/shacl/xkos-ap-no-shacl-v1.ttl[denne shacl-filen] som "Regelsett lenke")


### PR DESCRIPTION
For å få de siste endringene (rette opp brutte lenker) fra develop til v1 (og dermed også data.norge.no) 