### PR TITLE
ci: replace tonynv/asciidoctor-action with upstream docker image (refs #61)

### DIFF
--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -41,6 +41,13 @@ jobs:
           args: bash -c "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
+      # TEST-ONLY: validate that bash -c wrapper handles shell features (env interpolation, quoted literals, globs, pipes, multi-command).
+      # Output is grepped in the run log to confirm each feature evaluated. Removed before merging.
+      - name: Shell wrapper smoke test (test-only)
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
+        with:
+          args: bash -c "set -eu; echo SMOKE_ENV=run_id=$GITHUB_RUN_ID; echo 'SMOKE_QUOTED=literal text with spaces'; printf 'SMOKE_GLOB=found %s adoc files\n' $(ls docs/*.adoc | wc -l); echo SMOKE_MULTI=second-command-ran"
+
       # TEST-ONLY: expose build outputs so the test branch can diff against the gh-pages baseline.
       # Removed before merging — the production workflow only needs to deploy.
       - name: Upload built docs (test-only)

--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -18,7 +18,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           submodules: true
           fetch-depth: 0
@@ -30,19 +30,31 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
+      # TEST-ONLY: expose build outputs so the test branch can diff against the gh-pages baseline.
+      # Removed before merging — the production workflow only needs to deploy.
+      - name: Upload built docs (test-only)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: built-docs
+          path: |
+            docs/index.html
+            docs/files/xkos-ap-no.pdf
+          if-no-files-found: error
+
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        if: github.ref == 'refs/heads/develop'  # TEST-ONLY guard — removed before merging
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs

--- a/.github/workflows/adocs-build-develop.yml
+++ b/.github/workflows/adocs-build-develop.yml
@@ -41,26 +41,7 @@ jobs:
           args: bash -c "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
-      # TEST-ONLY: validate that bash -c wrapper handles shell features (env interpolation, quoted literals, globs, pipes, multi-command).
-      # Output is grepped in the run log to confirm each feature evaluated. Removed before merging.
-      - name: Shell wrapper smoke test (test-only)
-        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
-        with:
-          args: bash -c "set -eu; echo SMOKE_ENV=run_id=$GITHUB_RUN_ID; echo 'SMOKE_QUOTED=literal text with spaces'; printf 'SMOKE_GLOB=found %s adoc files\n' $(ls docs/*.adoc | wc -l); echo SMOKE_MULTI=second-command-ran"
-
-      # TEST-ONLY: expose build outputs so the test branch can diff against the gh-pages baseline.
-      # Removed before merging — the production workflow only needs to deploy.
-      - name: Upload built docs (test-only)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
-        with:
-          name: built-docs
-          path: |
-            docs/index.html
-            docs/files/xkos-ap-no.pdf
-          if-no-files-found: error
-
       - name: Deploy
-        if: github.ref == 'refs/heads/develop'  # TEST-ONLY guard — removed before merging
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces the unmaintained `tonynv/asciidoctor-action@master` (and its byte-identical fork `avattathil/asciidoctor-action@master`) in `adocs-build-develop.yml` with the upstream image `asciidoctor/docker-asciidoctor:1.106` pinned by digest, invoked as a per-step `docker://` action. Also pins `actions/checkout` and `peaceiris/actions-gh-pages` to SHAs.

This is the first of the org-wide unpinned-actions cleanup tracked in `Informasjonsforvaltning/fdk-issue-tracker#1256` to actually validate the proposed replacement on a live workflow. Refs this repo's per-repo issue #61.

## What changed

- `tonynv/asciidoctor-action@master` → `docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e057…` for both build steps.
- Both build steps wrap the command in `bash -c "<command>"` to preserve `tonynv/asciidoctor-action`'s shell semantics (its entrypoint was literally `bash -c "$@"`), so command lines that need env interpolation, pipes, redirects, globs, or multi-command sequencing keep working without further per-repo edits.
- `actions/checkout@v6` → SHA-pinned `de0fac2e…`
- `peaceiris/actions-gh-pages@v4` → SHA-pinned `4f9cc660…`

`v1/staging/legacy` workflows are intentionally not touched in this PR — once this merges and runs cleanly on `develop`, the same swap goes into `adocs-build-v1-*.yml` as a follow-up.

## Validation

Two `workflow_dispatch` runs on this branch (the test-only steps that produced them are removed in the final commit before merge):

**1. Output equivalence vs. current gh-pages baseline** — run [26095441499](https://github.com/Informasjonsforvaltning/xkos-ap-no/actions/runs/26095441499)

| Output | Baseline (tonynv, 2026-02-11) | After (Option A) | Result |
|---|---|---|---|
| `index.html` size | 284,690 bytes | 284,690 bytes | identical |
| `index.html` content | — | — | 1-line diff: regenerated "Sist oppdatert" footer timestamp only |
| `xkos-ap-no.pdf` size | 5,813,408 bytes | 5,813,408 bytes | identical |
| `xkos-ap-no.pdf` text (`pdftotext`) | 3,803 lines | 3,803 lines | `diff` returns 0 |
| PDF producer | `Asciidoctor PDF 2.3.24, based on Prawn 2.4.0` | same | unchanged |
| PDF page count | 69 | 69 | unchanged |

`docs/` source was unchanged between the baseline build commit (`89902a08`) and this branch's base, so the differences above are purely from the asciidoctor swap.

**2. `bash -c` wrapper exercises shell features** — run [26096045741](https://github.com/Informasjonsforvaltning/xkos-ap-no/actions/runs/26096045741)

The smoke step ran `bash -c "set -eu; echo SMOKE_ENV=run_id=$GITHUB_RUN_ID; echo 'SMOKE_QUOTED=literal text with spaces'; printf 'SMOKE_GLOB=found %s adoc files\n' $(ls docs/*.adoc | wc -l); echo SMOKE_MULTI=second-command-ran"` and produced in the log:

```
SMOKE_ENV=run_id=26096045741
SMOKE_QUOTED=literal text with spaces
SMOKE_GLOB=found 18 adoc files
SMOKE_MULTI=second-command-ran
```

i.e. env interpolation, quoted-string preservation, glob + pipe + command substitution, and multi-command sequencing all evaluate correctly through the wrapper inside the `docker://` step.