### PR TITLE
chore: pin third-party actions in v1 workflows (closes #61)

### DIFF
--- a/.github/workflows/adocs-build-v1-legacy.yml
+++ b/.github/workflows/adocs-build-v1-legacy.yml
@@ -18,7 +18,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: v1
           submodules: true
@@ -31,19 +31,19 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: html

--- a/.github/workflows/adocs-build-v1-production.yml
+++ b/.github/workflows/adocs-build-v1-production.yml
@@ -17,7 +17,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: v1
           submodules: true
@@ -30,19 +30,19 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
       - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd  # v3.2.0
         id: upload-rdf
         with:
           ontology-type: "specification"

--- a/.github/workflows/adocs-build-v1-staging.yml
+++ b/.github/workflows/adocs-build-v1-staging.yml
@@ -17,7 +17,7 @@ jobs:
     name: asciidoctor build
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: v1
           submodules: true
@@ -30,19 +30,19 @@ jobs:
 
       - name: Build html
         id: adocbuild
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
 
       - name: Build pdf
         id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
+        uses: docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e05784c2d8ece9d9fe5e593b12c3beebebbc467135fd6f4a56269c93cea3
         with:
-          program: "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
+          args: bash -c "asciidoctor-pdf -D docs -o files/xkos-ap-no.pdf -a lang=nb docs/main.adoc"
         continue-on-error: true
 
       - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
+        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@84beeeacd364f310ef6a253bc079354cdf62e5dd  # v3.2.0
         id: upload-rdf
         with:
           ontology-type: "specification"


### PR DESCRIPTION
Applies the same action pinning to the three v1 workflows (legacy, staging, production) that #62 applied to adocs-build-develop.yml. Together with #62 this closes #61 — all 16 unpinned third-party action references across all four workflows are now pinned to immutable commit SHAs.

Per-workflow changes:
- tonynv/asciidoctor-action@master → docker://asciidoctor/docker-asciidoctor:1.106@sha256:6266e057... (with bash -c wrapper)
- actions/checkout@v6 → @de0fac2e... (v6)
- peaceiris/actions-gh-pages@v4 → @4f9cc660... (v4)  [legacy only]
- Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0 → @84beeeac...  [production, staging]